### PR TITLE
Add a delay timer to prevent rapid triggering of GUI updates by the trackbar

### DIFF
--- a/Demo/Source/UMain.dfm
+++ b/Demo/Source/UMain.dfm
@@ -169,31 +169,37 @@ object MainForm: TMainForm
       Left = 0
       Top = 0
       Action = DisabledAction
+      ImageName = 'Business\businessman'
     end
     object ToolButton2: TToolButton
       Left = 39
       Top = 0
       Action = DeleteIconAction
+      ImageName = 'cancel'
     end
     object ToolButton3: TToolButton
       Left = 78
       Top = 0
       ImageIndex = 2
+      ImageName = 'calendar'
     end
     object ToolButton4: TToolButton
       Left = 117
       Top = 0
       ImageIndex = 3
+      ImageName = 'about'
     end
     object ToolButton5: TToolButton
       Left = 156
       Top = 0
       ImageIndex = 4
+      ImageName = 'calculator'
     end
     object ToolButton6: TToolButton
       Left = 195
       Top = 0
       Action = ChangeIconAction
+      ImageName = 'synchronize'
     end
     object ToolButton7: TToolButton
       Left = 234
@@ -201,6 +207,7 @@ object MainForm: TMainForm
       Caption = 'Change Color'
       Enabled = False
       ImageIndex = 7
+      ImageName = 'advertising'
       OnClick = ChangeColorActionExecute
     end
   end
@@ -235,6 +242,7 @@ object MainForm: TMainForm
       Height = 60
       Action = DeleteIconAction
       ImageAlignment = iaTop
+      ImageName = 'cancel'
       Images = SVGIconVirtualImageList
       TabOrder = 0
     end
@@ -245,6 +253,7 @@ object MainForm: TMainForm
       Height = 60
       Action = ChangeIconAction
       ImageAlignment = iaTop
+      ImageName = 'synchronize'
       Images = SVGIconVirtualImageList
       TabOrder = 1
     end
@@ -255,6 +264,7 @@ object MainForm: TMainForm
       Height = 60
       Action = NewFormAction
       ImageAlignment = iaTop
+      ImageName = 'frame'
       Images = SVGIconVirtualImageList
       TabOrder = 2
     end
@@ -358,6 +368,7 @@ object MainForm: TMainForm
   object SVGIconVirtualImageList: TSVGIconVirtualImageList
     Size = 32
     ImageCollection = ImageDataModule.SVGIconImageCollection
+    Scaled = True
     Left = 424
     Top = 336
   end
@@ -366,5 +377,12 @@ object MainForm: TMainForm
     Options = [ofHideReadOnly, ofAllowMultiSelect, ofPathMustExist, ofFileMustExist, ofEnableSizing]
     Left = 472
     Top = 72
+  end
+  object tmrTrackbar: TTimer
+    Enabled = False
+    Interval = 200
+    OnTimer = tmrTrackbarTimer
+    Left = 250
+    Top = 486
   end
 end

--- a/Demo/Source/UMain.pas
+++ b/Demo/Source/UMain.pas
@@ -84,6 +84,7 @@ type
     SVGIconVirtualImageList: TSVGIconVirtualImageList;
     NewFormButton: TButton;
     NewFormAction: TAction;
+    tmrTrackbar: TTimer;
     procedure ChangeIconActionExecute(Sender: TObject);
     procedure SelectThemeRadioGroupClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);
@@ -101,6 +102,7 @@ type
     procedure GrayScaleCheckBoxClick(Sender: TObject);
     procedure FixedColorComboBoxSelect(Sender: TObject);
     procedure NewFormActionExecute(Sender: TObject);
+    procedure tmrTrackbarTimer(Sender: TObject);
   private
     {$IFDEF D10_3+}
     VirtualImageList: TVirtualImageList;
@@ -349,6 +351,20 @@ begin
     SVGIconImage.ImageIndex := SVGIconImage.ImageIndex - 1;
 end;
 
+procedure TMainForm.tmrTrackbarTimer(Sender: TObject);
+begin
+  // Disable trackbar while updating. Otherwise a second event will be fired
+  TrackBar.Enabled := false;
+  try
+    tmrTrackbar.Enabled := false;
+    //Resize all icons into ImageList
+    SVGIconVirtualImageList.Size := TrackBar.Position;
+    UpdateGUI;
+  finally
+    TrackBar.Enabled := true;
+  end;
+end;
+
 procedure TMainForm.updateGUI;
 var
   LSize: Integer;
@@ -410,9 +426,7 @@ end;
 
 procedure TMainForm.TrackBarChange(Sender: TObject);
 begin
-  //Resize all icons into ImageList
-  SVGIconVirtualImageList.Size := TrackBar.Position;
-  UpdateGUI;
+  tmrTrackbar.Enabled := true;
 end;
 
 initialization


### PR DESCRIPTION
The ImageName properties in the .dfm were added by the IDE (10.4.1). I hope we are not running into an Explicit* properties nightmare here.