### PR TITLE
Replace all {$IFDEF WIN32} by {$IFDEF MSWINDOWS} to make cairo compile under Win64

### DIFF
--- a/Cairo/cairo.inc
+++ b/Cairo/cairo.inc
@@ -16,7 +16,7 @@
   {$DEFINE CAIRO_HAS_FT_FONT}
 {$ENDIF}
 
-{$ifdef WIN32}
+{$ifdef MSWINDOWS}
   {$define CAIRO_HAS_WIN32_SURFACE}
   {$define CAIRO_HAS_WIN32_FONT}
 {$endif}

--- a/Cairo/cairo.pas
+++ b/Cairo/cairo.pas
@@ -28,6 +28,7 @@
  *)
 
 unit cairo;
+
 {$IFDEF FPC}
   {$MODE OBJFPC}{$H+}
 {$ENDIF}
@@ -36,7 +37,7 @@ unit cairo;
 
 interface
 uses sysutils, classes, cairolib
-{$IFDEF WIN32}
+{$IFDEF MSWINDOWS}
 , windows
 {$ENDIF}
 {$IFDEF CAIRO_HAS_RSVG_FUNCTIONS}
@@ -2859,3 +2860,4 @@ begin
 end;
 
 end.
+

--- a/Cairo/cairolib.pas
+++ b/Cairo/cairolib.pas
@@ -47,9 +47,9 @@ unit cairolib;
 
 interface
 
-{$ifdef WIN32}
+{$IFDEF MSWINDOWS}
 uses windows;
-{$endif}
+{$ENDIF}
 
 {$ifdef UNIX}
 uses x, xlib, xrender, freetypeh;

--- a/Demo/Benchmark/Benchmark.dproj
+++ b/Demo/Benchmark/Benchmark.dproj
@@ -4,9 +4,9 @@
         <ProjectVersion>19.1</ProjectVersion>
         <FrameworkType>VCL</FrameworkType>
         <Base>True</Base>
-        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Config Condition="'$(Config)'==''">Release</Config>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
-        <TargetedPlatforms>1</TargetedPlatforms>
+        <TargetedPlatforms>3</TargetedPlatforms>
         <AppType>Application</AppType>
         <MainSource>Benchmark.dpr</MainSource>
     </PropertyGroup>
@@ -34,6 +34,12 @@
         <Cfg_1>true</Cfg_1>
         <Base>true</Base>
     </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win64)'!=''">
+        <Cfg_1_Win64>true</Cfg_1_Win64>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
         <Cfg_2>true</Cfg_2>
         <CfgParent>Base</CfgParent>
@@ -41,6 +47,12 @@
     </PropertyGroup>
     <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_2)'=='true') or '$(Cfg_2_Win32)'!=''">
         <Cfg_2_Win32>true</Cfg_2_Win32>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Cfg_2)'=='true') or '$(Cfg_2_Win64)'!=''">
+        <Cfg_2_Win64>true</Cfg_2_Win64>
         <CfgParent>Cfg_2</CfgParent>
         <Cfg_2>true</Cfg_2>
         <Base>true</Base>
@@ -75,6 +87,11 @@ $(PostBuildEvent)]]></PostBuildEvent>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64)'!=''">
         <DCC_UsePackage>DBXSqliteDriver;IndyIPCommon;RESTComponents;bindcompdbx;DBXInterBaseDriver;vcl;IndyIPServer;vclactnband;TMSVCLUIPackPkgExDXE13;vclFireDAC;IndySystem;bindcompvclsmp;tethering;dsnapcon;FireDACADSDriver;VirtualTreesR;FireDACMSAccDriver;fmxFireDAC;vclimg;TeeDB;FireDAC;vcltouch;vcldb;bindcompfmx;FireDACSqliteDriver;FireDACPgDriver;inetdb;FMXTee;soaprtl;DbxCommonDriver;FmxTeeUI;fmx;FireDACIBDriver;fmxdae;xmlrtl;soapmidas;vcledge;fmxobj;vclwinx;Tee;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;dbexpress;IndyCore;vclx;bindcomp;appanalytics;dsnap;FireDACCommon;IndyIPClient;bindcompvcl;RESTBackendComponents;TeeUI;VCLRESTComponents;soapserver;dbxcds;VclSmp;adortl;TMSVCLUIPackPkgDXE13;vclie;bindengine;DBXMySQLDriver;CloudService;dsnapxml;FireDACMySQLDriver;dbrtl;IndyProtocols;inetdbxpress;FireDACCommonODBC;FireDACCommonDriver;inet;fmxase;$(DCC_UsePackage)</DCC_UsePackage>
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
         <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
@@ -91,6 +108,10 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win64)'!=''">
+        <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
+        <AppDPIAwarenessMode>PerMonitorV2</AppDPIAwarenessMode>
+    </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
         <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
         <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
@@ -98,6 +119,10 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <DCC_DebugInformation>0</DCC_DebugInformation>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
+        <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
+        <AppDPIAwarenessMode>PerMonitorV2</AppDPIAwarenessMode>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_Win64)'!=''">
         <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
         <AppDPIAwarenessMode>PerMonitorV2</AppDPIAwarenessMode>
     </PropertyGroup>
@@ -904,7 +929,7 @@ $(PostBuildEvent)]]></PostBuildEvent>
             </Deployment>
             <Platforms>
                 <Platform value="Win32">True</Platform>
-                <Platform value="Win64">False</Platform>
+                <Platform value="Win64">True</Platform>
             </Platforms>
         </BorlandProject>
         <ProjectFileVersion>12</ProjectFileVersion>
@@ -917,7 +942,7 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <PreBuildEventIgnoreExitCode>False</PreBuildEventIgnoreExitCode>
         <PreLinkEvent/>
         <PreLinkEventIgnoreExitCode>False</PreLinkEventIgnoreExitCode>
-        <PostBuildEvent>powershell.exe Expand-Archive -Force ..\..\Cairo\Dlls\librsvg-$(PLATFORM).zip $(OUTPUTDIR)</PostBuildEvent>
+        <PostBuildEvent>powershell.exe Expand-Archive -Force ..\..\Cairo\Dlls\librsvg-$(PLATFORM).zip $(OUTPUTDIR)</PostBuildEvent>
         <PostBuildEventIgnoreExitCode>False</PostBuildEventIgnoreExitCode>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Debug' And '$(Platform)'=='Win64'">
@@ -925,7 +950,7 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <PreBuildEventIgnoreExitCode>False</PreBuildEventIgnoreExitCode>
         <PreLinkEvent/>
         <PreLinkEventIgnoreExitCode>False</PreLinkEventIgnoreExitCode>
-        <PostBuildEvent>powershell.exe Expand-Archive -Force ..\..\Cairo\Dlls\librsvg-$(PLATFORM).zip $(OUTPUTDIR)</PostBuildEvent>
+        <PostBuildEvent>powershell.exe Expand-Archive -Force ..\..\Cairo\Dlls\librsvg-$(PLATFORM).zip $(OUTPUTDIR)</PostBuildEvent>
         <PostBuildEventIgnoreExitCode>False</PostBuildEventIgnoreExitCode>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Release' And '$(Platform)'=='Win32'">
@@ -933,7 +958,7 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <PreBuildEventIgnoreExitCode>False</PreBuildEventIgnoreExitCode>
         <PreLinkEvent/>
         <PreLinkEventIgnoreExitCode>False</PreLinkEventIgnoreExitCode>
-        <PostBuildEvent>powershell.exe Expand-Archive -Force ..\..\Cairo\Dlls\librsvg-$(PLATFORM).zip $(OUTPUTDIR)</PostBuildEvent>
+        <PostBuildEvent>powershell.exe Expand-Archive -Force ..\..\Cairo\Dlls\librsvg-$(PLATFORM).zip $(OUTPUTDIR)</PostBuildEvent>
         <PostBuildEventIgnoreExitCode>False</PostBuildEventIgnoreExitCode>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Release' And '$(Platform)'=='Win64'">
@@ -941,7 +966,7 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <PreBuildEventIgnoreExitCode>False</PreBuildEventIgnoreExitCode>
         <PreLinkEvent/>
         <PreLinkEventIgnoreExitCode>False</PreLinkEventIgnoreExitCode>
-        <PostBuildEvent>powershell.exe Expand-Archive -Force ..\..\Cairo\Dlls\librsvg-$(PLATFORM).zip $(OUTPUTDIR)</PostBuildEvent>
+        <PostBuildEvent>powershell.exe Expand-Archive -Force ..\..\Cairo\Dlls\librsvg-$(PLATFORM).zip $(OUTPUTDIR)</PostBuildEvent>
         <PostBuildEventIgnoreExitCode>False</PostBuildEventIgnoreExitCode>
     </PropertyGroup>
 </Project>

--- a/Demo/Benchmark/UBenchmark.dfm
+++ b/Demo/Benchmark/UBenchmark.dfm
@@ -36,10 +36,6 @@ object frmBenchmark: TfrmBenchmark
     Font.Style = []
     ParentFont = False
     TabOrder = 0
-    ExplicitLeft = 24
-    ExplicitTop = 24
-    ExplicitWidth = 385
-    ExplicitHeight = 281
   end
   object SVGIconImage: TSVGIconImage
     Left = 463
@@ -49,7 +45,6 @@ object frmBenchmark: TfrmBenchmark
     AutoSize = False
     ImageList = imlIcons
     Align = alRight
-    ExplicitLeft = 483
   end
   object pnlBottom: TPanel
     Left = 0
@@ -59,8 +54,6 @@ object frmBenchmark: TfrmBenchmark
     Align = alBottom
     BevelOuter = bvNone
     TabOrder = 2
-    ExplicitTop = 302
-    ExplicitWidth = 712
     object lblLoops: TLabel
       AlignWithMargins = True
       Left = 550
@@ -74,8 +67,6 @@ object frmBenchmark: TfrmBenchmark
       Align = alRight
       Caption = '&Loops'
       FocusControl = speLoops
-      ExplicitLeft = 480
-      ExplicitTop = 20
       ExplicitHeight = 13
     end
     object btnClear: TButton
@@ -88,9 +79,6 @@ object frmBenchmark: TfrmBenchmark
       Caption = '&Clear'
       TabOrder = 0
       OnClick = btnClearClick
-      ExplicitLeft = 8
-      ExplicitTop = 6
-      ExplicitHeight = 25
     end
     object btnLoad: TButton
       AlignWithMargins = True
@@ -102,9 +90,6 @@ object frmBenchmark: TfrmBenchmark
       Caption = 'L&oad Image'
       TabOrder = 1
       OnClick = btnLoadClick
-      ExplicitLeft = 114
-      ExplicitTop = 6
-      ExplicitHeight = 25
     end
     object btnRunBenchmark: TButton
       AlignWithMargins = True
@@ -120,9 +105,6 @@ object frmBenchmark: TfrmBenchmark
       Caption = '&Benchmark'
       TabOrder = 2
       OnClick = btnRunBenchmarkClick
-      ExplicitLeft = 607
-      ExplicitTop = 16
-      ExplicitHeight = 25
     end
     object speLoops: TSpinEdit
       AlignWithMargins = True
@@ -136,12 +118,37 @@ object frmBenchmark: TfrmBenchmark
       Margins.Bottom = 8
       Align = alRight
       MaxValue = 999
-      MinValue = 10
+      MinValue = 1
       TabOrder = 3
       Value = 50
-      ExplicitLeft = 520
-      ExplicitTop = 19
-      ExplicitHeight = 22
+    end
+    object chkGrayScale: TCheckBox
+      AlignWithMargins = True
+      Left = 342
+      Top = 3
+      Width = 97
+      Height = 34
+      Align = alRight
+      Caption = '&Grayscale'
+      Checked = True
+      State = cbChecked
+      TabOrder = 4
+      ExplicitLeft = 333
+      ExplicitTop = 6
+    end
+    object chkFixedColor: TCheckBox
+      AlignWithMargins = True
+      Left = 445
+      Top = 3
+      Width = 97
+      Height = 34
+      Align = alRight
+      Caption = '&Fixed Color'
+      Checked = True
+      State = cbChecked
+      TabOrder = 5
+      ExplicitLeft = 263
+      ExplicitTop = 6
     end
   end
   object SVGIconImageCollection: TSVGIconImageCollection


### PR DESCRIPTION
Fixes #124 