### PR TITLE
Fixed TSVGIconImageCollection registration for FMX projects

### DIFF
--- a/Source/SVGIconImageCollection.pas
+++ b/Source/SVGIconImageCollection.pas
@@ -139,6 +139,7 @@ implementation
 
 uses
   System.SysUtils
+  , VCL.Controls
   , {$IFDEF DXE4+}System.Messaging{$ELSE}SVGMessaging{$ENDIF};
 
 { TSVGIconImageCollection }
@@ -526,5 +527,14 @@ begin
 
   LSVG.PaintTo(ACanvas.Handle, TRectF.Create(ARect), AProportional);
 end;
+
+initialization
+
+{$IF NOT DEFINED(CLR)}
+  StartClassGroup(VCL.Controls.TControl);
+  ActivateClassGroup(VCL.Controls.TControl);
+  GroupDescendentsWith(TSVGIconImageCollection, VCL.Controls.TControl);
+{$ENDIF}
+
 
 end.


### PR DESCRIPTION
Hi
TSVGIconImageCollection is a VCL only component but appeared on FMX components list because its ancestor is not registered as a VCL only component or class. I fixed the problem by using the class grouping.
Best regards
Patrick Prémartin