### PR TITLE
Fix W1063 warning in IsBlankText by using WideChar($A0)

### DIFF
--- a/Image32/source/Img32.SVG.Reader.pas
+++ b/Image32/source/Img32.SVG.Reader.pas
@@ -996,7 +996,7 @@ var
 begin
   Result := false;
   for i := 1 to Length(text) do
-    if (text[i] > #32) and (text[i] <> #160) then Exit;
+    if (text[i] > #32) and (text[i] <> WideChar($A0)) then Exit;
   Result := true;
 end;
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the W1063 warning ("Widening given AnsiChar constant to WideChar lost information") in the `IsBlankText` function. Replace `#160` with `WideChar($A0)` in `IsBlankText` to avoid W1063 warning.

Compiled and tested with D12, no warning observed.

